### PR TITLE
fix: 장바구니 목록 조회 오류 수정'

### DIFF
--- a/src/main/java/com/example/pillyohae/cart/dto/CartProductDetailResponseDto.java
+++ b/src/main/java/com/example/pillyohae/cart/dto/CartProductDetailResponseDto.java
@@ -9,7 +9,7 @@ public class CartProductDetailResponseDto {
 
     private final Long productId;
     private final String name;
-    private final String ImageUrl;
+    private final String imageUrl;
     private final Long price;
     private final Integer quantity;
 }

--- a/src/main/java/com/example/pillyohae/cart/dto/CartProductDetailResponseDto.java
+++ b/src/main/java/com/example/pillyohae/cart/dto/CartProductDetailResponseDto.java
@@ -1,15 +1,27 @@
 package com.example.pillyohae.cart.dto;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
 public class CartProductDetailResponseDto {
 
     private final Long productId;
-    private final String name;
+    private final String productName;
     private final String imageUrl;
     private final Long price;
     private final Integer quantity;
+
+    public CartProductDetailResponseDto(
+        Long productId,
+        String productName,
+        String imageUrl,
+        Long price,
+        Integer quantity
+    ) {
+        this.productId = productId;
+        this.productName = productName;
+        this.imageUrl = imageUrl;
+        this.price = price;
+        this.quantity = quantity;
+    }
 }

--- a/src/main/java/com/example/pillyohae/cart/repository/CartRepository.java
+++ b/src/main/java/com/example/pillyohae/cart/repository/CartRepository.java
@@ -10,12 +10,12 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface CartRepository extends JpaRepository<Cart, Long> {
 
-    @Query("SELECT " +
+    @Query("SELECT new com.example.pillyohae.cart.dto.CartProductDetailResponseDto(" +
         "c.product.productId," +
         "c.product.productName," +
         "c.product.imageUrl," +
         "c.product.price," +
-        "c.quantity " +
+        "c.quantity) " +
         "FROM Cart c " +
         "WHERE c.user.id = :userId")
     List<CartProductDetailResponseDto> findCartDtoListByUserId(Long userId);


### PR DESCRIPTION
CartRepository에서 JPQL을 사용해 DTO를 반환할 때 생성자를 붙이지 않아 발생한 오류를 수정했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new constructor for `CartProductDetailResponseDto` to enhance field initialization.
	- Updated repository method to return a list of `CartProductDetailResponseDto` objects directly.

- **Style**
	- Updated variable naming in `CartProductDetailResponseDto` to follow Java naming conventions by changing `ImageUrl` to `imageUrl` and `name` to `productName`.

- **Refactor**
	- Modified cart repository query to directly construct `CartProductDetailResponseDto` objects, improving query efficiency and code readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->