### PR TITLE
fix,refactor: filter whitelist 관련 오류, 리팩터링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,8 +70,8 @@ dependencies {
     // json-simple
     implementation 'com.googlecode.json-simple:json-simple:1.1.1'
 
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 }
-
 
 
 tasks.named('test') {

--- a/src/main/java/com/example/pillyohae/global/config/SecurityProperties.java
+++ b/src/main/java/com/example/pillyohae/global/config/SecurityProperties.java
@@ -1,0 +1,25 @@
+package com.example.pillyohae.global.config;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+
+// application.yml의 security: 아래 설정들을 이 클래스와 매핑
+@ConfigurationProperties(prefix = "security")
+@Component
+@Getter
+@Setter
+public class SecurityProperties {
+
+    private List<String> whiteList = new ArrayList<>();  // security.white-list와 매핑
+    private List<String> sellerAuthList = new ArrayList<>(); // security.seller-auth-list와 매핑
+
+    // security.method-specific-patterns와 매핑
+    private Map<HttpMethod, List<String>> methodSpecificPatterns = new HashMap<>();
+}

--- a/src/main/java/com/example/pillyohae/global/filter/JwtAuthFilter.java
+++ b/src/main/java/com/example/pillyohae/global/filter/JwtAuthFilter.java
@@ -1,5 +1,6 @@
 package com.example.pillyohae.global.filter;
 
+import com.example.pillyohae.global.config.SecurityProperties;
 import com.example.pillyohae.global.util.AuthenticationScheme;
 import com.example.pillyohae.global.util.JwtProvider;
 import jakarta.servlet.FilterChain;
@@ -8,14 +9,17 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -27,21 +31,36 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 
     private final UserDetailsService userDetailsService;
 
-    // 화이트리스트 경로 정의
-    private static final List<String> WHITE_LIST = List.of("/users/login", "/users/signup", "/users/products/**", "/toss/fail", "/toss/success", "/toss/confirm", "/products");
+    private final SecurityProperties securityProperties;
+    private final AntPathMatcher pathMatcher = new AntPathMatcher();
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+    protected void doFilterInternal(HttpServletRequest request,
+        HttpServletResponse response,
         FilterChain filterChain) throws ServletException, IOException {
 
+        // 화이트 리스트를 판단하기 위한 uri 와 method
         String requestUri = request.getRequestURI();
+        String method = request.getMethod();
 
-        // 화이트리스트 경로인 경우 필터링을 건너뜀
-        if (!WHITE_LIST.contains(requestUri)) {
-            this.authenticate(request);
+        // SecurityProperties에서 설정값들을 가져와서 사용
+        if (securityProperties.getWhiteList().stream()
+            .anyMatch(pattern -> pathMatcher.match(pattern, requestUri))) {
+            filterChain.doFilter(request, response);
+            return;
         }
 
+        // HTTP Method 특정 패턴 체크, (GET /products/search 를 필터링 하지 않기위해 구현)
+        Map<HttpMethod, List<String>> methodPatterns = securityProperties.getMethodSpecificPatterns();
+        if (methodPatterns.containsKey(HttpMethod.valueOf(method))) {
+            if (methodPatterns.get(HttpMethod.valueOf(method)).stream()
+                .anyMatch(pattern -> pathMatcher.match(pattern, requestUri))) {
+                filterChain.doFilter(request, response);
+                return;
+            }
+        }
 
+        this.authenticate(request);
         filterChain.doFilter(request, response);
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,3 @@
-
-
 spring:
   application:
     name: pillyohae
@@ -19,7 +17,7 @@ spring:
     database-platform: org.hibernate.dialect.MySQL8Dialect
     database: mysql
     hibernate:
-      ddl-auto: validate
+      ddl-auto: create-drop
       naming:
         physical-strategy: org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy
     generate-ddl: false
@@ -61,4 +59,17 @@ cloud:
       access-key: ${ACCESS_KEY} # ACCESS_KEY 없으면 default-access-key 사용
       secret-key: ${SECRET_KEY} # SECRET_KEY 없으면 default-secret-key 사용
 
-
+security: # SecurityProperties의 prefix와 일치
+  white-list: # SecurityProperties의 whiteList 필드와 매핑
+    - "/users/login"
+    - "/users/signup"
+    - "/toss/fail"
+    - "/toss/success"
+    - "/toss/confirm"
+  seller-auth-list:
+    - "/users/sellers/**"
+    - "/products"
+    - "/products/**"
+  method-specific-patterns:
+    GET:
+      - "/products/*"


### PR DESCRIPTION
@ConfigurationProperties 을 사용하여
SecurityProperties 생성

JwtAuthFilter 와 WebConfig 에서 두번 선언해주던 whitelist 를
application.yml 파일에 whitelist 경로를 설정으로 등록해주고
각 클래스에서 SecurityProperties 를 의존성 주입받아
whitelist/ 인가 필요한 경로 / 인증,인가에 걸리지 않을 예외 경로
정보를 application.yml 파일에서 가져오고
그것을 사용하여 경로 설정을 하도록 수정