### PR TITLE
feat: openAI 로 페르소나 생성 API 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,6 @@ dependencies {
 
     // spring AI (OpenAI)
     implementation platform("org.springframework.ai:spring-ai-bom:1.0.0-SNAPSHOT")
-    // Replace the following with the starter dependencies of specific modules you wish to use
     implementation 'org.springframework.ai:spring-ai-openai'
     implementation 'org.springframework.ai:spring-ai-openai-spring-boot-starter'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,8 @@ dependencies {
     // json-simple
     implementation 'com.googlecode.json-simple:json-simple:1.1.1'
 
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
+
     // spring AI (OpenAI)
     implementation platform("org.springframework.ai:spring-ai-bom:1.0.0-SNAPSHOT")
     implementation 'org.springframework.ai:spring-ai-openai'

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,8 @@ configurations {
 
 repositories {
     mavenCentral()
+    maven { url 'https://repo.spring.io/milestone' }
+    maven { url 'https://repo.spring.io/snapshot' }
 }
 
 dependencies {
@@ -70,7 +72,11 @@ dependencies {
     // json-simple
     implementation 'com.googlecode.json-simple:json-simple:1.1.1'
 
-    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
+    // spring AI (OpenAI)
+    implementation platform("org.springframework.ai:spring-ai-bom:1.0.0-SNAPSHOT")
+    // Replace the following with the starter dependencies of specific modules you wish to use
+    implementation 'org.springframework.ai:spring-ai-openai'
+    implementation 'org.springframework.ai:spring-ai-openai-spring-boot-starter'
 }
 
 

--- a/src/main/java/com/example/pillyohae/global/config/WebConfig.java
+++ b/src/main/java/com/example/pillyohae/global/config/WebConfig.java
@@ -41,6 +41,7 @@ public class WebConfig {
                 .permitAll()
                 .requestMatchers(HttpMethod.GET, "/products/*").permitAll()
                 .requestMatchers(HttpMethod.GET, "/products").permitAll()
+                .requestMatchers(HttpMethod.POST, "/persona/*").permitAll()
                 .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
                 .dispatcherTypeMatchers(DispatcherType.FORWARD, DispatcherType.INCLUDE,
                     DispatcherType.ERROR).permitAll()

--- a/src/main/java/com/example/pillyohae/persona/PersonaController.java
+++ b/src/main/java/com/example/pillyohae/persona/PersonaController.java
@@ -1,0 +1,31 @@
+package com.example.pillyohae.persona;
+
+
+import org.springframework.ai.image.Image;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/persona")
+public class PersonaController {
+
+    @Autowired
+    private PersonaService personaService;
+
+    @PostMapping("/generate")
+    public ResponseEntity<List<Image>> generatePersona(@RequestParam("imageUrl") String productImageUrl) {
+        try {
+            var personaImageUrl = personaService.generatePersonaFromProduct(productImageUrl);
+            return ResponseEntity.ok(personaImageUrl);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+}

--- a/src/main/java/com/example/pillyohae/persona/PersonaController.java
+++ b/src/main/java/com/example/pillyohae/persona/PersonaController.java
@@ -13,14 +13,14 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/persona")
+@RequestMapping("/persona")
 public class PersonaController {
 
     @Autowired
     private PersonaService personaService;
 
     @PostMapping("/generate")
-    public ResponseEntity<List<Image>> generatePersona(@RequestParam("imageUrl") String productImageUrl) {
+    public ResponseEntity<Image> generatePersona(@RequestParam("imageUrl") String productImageUrl) {
         try {
             var personaImageUrl = personaService.generatePersonaFromProduct(productImageUrl);
             return ResponseEntity.ok(personaImageUrl);

--- a/src/main/java/com/example/pillyohae/persona/PersonaService.java
+++ b/src/main/java/com/example/pillyohae/persona/PersonaService.java
@@ -1,0 +1,85 @@
+package com.example.pillyohae.persona;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.image.Image;
+import org.springframework.ai.image.ImageGeneration;
+import org.springframework.ai.image.ImagePrompt;
+import org.springframework.ai.image.ImageResponse;
+import org.springframework.ai.model.Media;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.ai.openai.OpenAiImageModel;
+import org.springframework.ai.openai.OpenAiImageOptions;
+import org.springframework.ai.openai.api.OpenAiApi;
+import org.springframework.stereotype.Service;
+import org.springframework.util.MimeTypeUtils;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PersonaService {
+
+    private final OpenAiImageModel openAiImageModel;
+    private final OpenAiChatModel chatModel;
+
+    public List<Image> generatePersonaFromProduct(String productImageUrl) {
+        // 1. 상품 이미지 분석
+        String productDescription = analyzeProductImage(productImageUrl);
+
+        // 2. 페르소나 프롬프트 생성
+        String prompt = createPersonaPrompt(productDescription);
+
+        // 3. 이미지 생성 요청
+        return generatePersonaImages(prompt);
+    }
+
+    private String analyzeProductImage(String imageUrl) {
+        // Vision API를 사용하여 상품 이미지 분석
+        UserMessage userMessage;
+        try {
+            userMessage = new UserMessage("Please explain the main characteristics by analyzing only the product excluding the background from the product image.",
+                    new Media(MimeTypeUtils.IMAGE_PNG, new URL(imageUrl)));
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+
+        ChatResponse response = chatModel.call(new Prompt(userMessage,
+                OpenAiChatOptions.builder().model(OpenAiApi.ChatModel.GPT_4_O.getValue()).build()));
+
+        return response.getResult().getOutput().getContent();
+    }
+
+    private String createPersonaPrompt(String productDescription) {
+        // 비용 절감을 위한 효율적인 프롬프트 생성
+        return String.format(
+                "Create a cute cartoon character persona based on this product: %s. " +
+                        "Style: anime-inspired, friendly mascot. " +
+                        "Make it simple but appealing, suitable for marketing.",
+                productDescription
+        );
+    }
+
+    private List<Image> generatePersonaImages(String prompt) {
+        OpenAiImageOptions options = OpenAiImageOptions.builder()
+                                .quality("hd")
+                                .N(4)
+                                .height(512)
+                                .width(512).build();
+
+        ImageResponse response = openAiImageModel.call(
+                new ImagePrompt(prompt, options)
+        );
+
+        return response.getResults()
+                .stream()
+                .map(ImageGeneration::getOutput)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/example/pillyohae/persona/PersonaService.java
+++ b/src/main/java/com/example/pillyohae/persona/PersonaService.java
@@ -1,11 +1,11 @@
 package com.example.pillyohae.persona;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.image.Image;
-import org.springframework.ai.image.ImageGeneration;
 import org.springframework.ai.image.ImagePrompt;
 import org.springframework.ai.image.ImageResponse;
 import org.springframework.ai.model.Media;
@@ -19,9 +19,8 @@ import org.springframework.util.MimeTypeUtils;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.List;
-import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PersonaService {
@@ -29,12 +28,14 @@ public class PersonaService {
     private final OpenAiImageModel openAiImageModel;
     private final OpenAiChatModel chatModel;
 
-    public List<Image> generatePersonaFromProduct(String productImageUrl) {
+    public Image generatePersonaFromProduct(String productImageUrl) {
         // 1. 상품 이미지 분석
         String productDescription = analyzeProductImage(productImageUrl);
+        log.info("productDescription : {}, productImageUrl: {}", productDescription, productImageUrl);
 
         // 2. 페르소나 프롬프트 생성
         String prompt = createPersonaPrompt(productDescription);
+        log.info("persona prompt : {}, productImageUrl: {}", productDescription, productImageUrl);
 
         // 3. 이미지 생성 요청
         return generatePersonaImages(prompt);
@@ -66,20 +67,17 @@ public class PersonaService {
         );
     }
 
-    private List<Image> generatePersonaImages(String prompt) {
+    private Image generatePersonaImages(String prompt) {
         OpenAiImageOptions options = OpenAiImageOptions.builder()
                                 .quality("hd")
-                                .N(4)
-                                .height(512)
-                                .width(512).build();
+                                .N(1)
+                                .height(1024)
+                                .width(1024).build();
 
         ImageResponse response = openAiImageModel.call(
                 new ImagePrompt(prompt, options)
         );
 
-        return response.getResults()
-                .stream()
-                .map(ImageGeneration::getOutput)
-                .collect(Collectors.toList());
+        return response.getResults().get(0).getOutput();
     }
 }

--- a/src/main/java/com/example/pillyohae/persona/PersonaService.java
+++ b/src/main/java/com/example/pillyohae/persona/PersonaService.java
@@ -35,7 +35,7 @@ public class PersonaService {
 
         // 2. 페르소나 프롬프트 생성
         String prompt = createPersonaPrompt(productDescription);
-        log.info("persona prompt : {}, productImageUrl: {}", productDescription, productImageUrl);
+        log.info("persona prompt : {}, productImageUrl: {}", prompt, productImageUrl);
 
         // 3. 이미지 생성 요청
         return generatePersonaImages(prompt);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,8 +40,6 @@ spring:
       image:
         options:
           model: dall-e-3  # 기본 이미지 모델 설정
-          quality: hd      # HD 품질 설정 (dall-e-3에서만 지원)
-          size: 512x512    # 이미지 크기 설정
 
 toss:
   secret-key: ${TOSS_SECRET_KEY}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,8 +34,14 @@ spring:
           generate_statistics: true
   config:
     import: optional:file:.env[.properties]
-
-
+  ai:
+    openai:
+      api-key: ${OPENAI_API_KEY}
+      image:
+        options:
+          model: dall-e-3  # 기본 이미지 모델 설정
+          quality: hd      # HD 품질 설정 (dall-e-3에서만 지원)
+          size: 512x512    # 이미지 크기 설정
 
 toss:
   secret-key: ${TOSS_SECRET_KEY}

--- a/src/main/resources/persona.http
+++ b/src/main/resources/persona.http
@@ -1,0 +1,5 @@
+### GET request to example server
+GET https://examples.http-client.intellij.net/get
+    ?generated-in=IntelliJ IDEA
+
+###

--- a/src/main/resources/persona.http
+++ b/src/main/resources/persona.http
@@ -1,5 +1,2 @@
 ### GET request to example server
-GET https://examples.http-client.intellij.net/get
-    ?generated-in=IntelliJ IDEA
-
-###
+POST http://localhost:8080/persona/generate?imageUrl=https://static.lottedfs.com/prod/prd-img/59/27/62/00/00/02/20000622759_1.jpg


### PR DESCRIPTION
### # 변경 내용
- 약 이미지를 업로드하면 해당 약의 페르소나 이미지를 생성해주는 API 기능 추가
- `OPENAI_API_KEY` 환경설정 필요 ([참고 링크](https://velog.io/@ji1kang/OpenAI%EC%9D%98-API-Key-%EB%B0%9C%EA%B8%89-%EB%B0%9B%EA%B3%A0-%ED%85%8C%EC%8A%A4%ED%8A%B8-%ED%95%98%EA%B8%B0))
- `POST /persona/generate?imageUrl={상품이미지URL}`
    - JPG, JPEG, PNG 포멧의 이미지 파일만 업로드 요청 가능
    - HD 화질의 1024*1024 해상도 이미지 1개 생성 응답

> 약 설명을 추가하려고 했는데 이미 약이미지에 이름도 나와있다보니
> GPT 가 약 이름만봐도 어떤 약인지 알아서, 굳이 설명 안넣었습니다.

- 생성 이미지 샘플
<img src="https://github.com/user-attachments/assets/ed5a2e32-107d-4a34-95a6-eff0379e721f" width="200" height="200"/>
<img src="https://github.com/user-attachments/assets/1dc1d678-1f09-4566-82bf-e8eccdc2fda7" width="200" height="200"/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리즈 노트

- **새로운 기능**
  - 제품 이미지를 기반으로 페르소나 생성 기능 추가
  - OpenAI의 DALL-E 3 모델을 활용한 이미지 생성 지원

- **구성 변경**
  - Spring AI 의존성 추가
  - OpenAI API 통합을 위한 구성 설정 업데이트

- **보안**
  - `/persona/*` 엔드포인트에 대한 POST 요청에 대한 인증 없는 접근 허용

이번 릴리즈는 사용자에게 더욱 풍부한 이미지 생성 경험을 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->