### PR TITLE
refactor: CORS 설정 리팩터링

### DIFF
--- a/src/main/java/com/example/pillyohae/global/config/WebConfig.java
+++ b/src/main/java/com/example/pillyohae/global/config/WebConfig.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -16,6 +17,9 @@ import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.access.ExceptionTranslationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 
 @Configuration
@@ -33,8 +37,21 @@ public class WebConfig {
     private final SecurityProperties securityProperties;
 
     @Bean
+    CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.addAllowedOriginPattern("*"); // 모든 출처 허용
+        configuration.addAllowedMethod("*"); // 모든 HTTP 메서드 허용
+        configuration.addAllowedHeader("*"); // 모든 헤더 허용
+        configuration.setAllowCredentials(true); // 인증 정보 포함 허용
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+
+    @Bean
     SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        http.cors(AbstractHttpConfigurer::disable)
+        http.cors(Customizer.withDefaults())
             .csrf(AbstractHttpConfigurer::disable)
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers(securityProperties.getWhiteList().toArray(new String[0]))


### PR DESCRIPTION
WebConfig에서 SecurityFilterChain에 CORS 를 disabled
로 생성하면 프론트 단과 연결이 되지않는 문제를 해결하기위해
CorsConfigurationSource 를 Bean 으로 등록하여
CorsConfiguration 으로 모든 출처, 메서드, 헤더, 인증정보
를 포함할 수 있도록 설정하고
SecurityFilterChain에 해당 cors 를 적용하도록 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 크로스 오리진 리소스 공유(CORS) 구성을 업데이트하여 모든 출처, 메서드, 헤더에 대한 요청을 허용하도록 설정
	- 애플리케이션의 교차 출처 요청 처리 능력 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->