### PR TITLE
refactor: 블랙 리스트 조회 과정에 캐싱 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,9 +52,12 @@ dependencies {
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
+    //caffeine
+    implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
+    
     //redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-    
+
     // lombok
     annotationProcessor 'org.projectlombok:lombok'
     compileOnly 'org.projectlombok:lombok'

--- a/src/test/java/com/example/pillyohae/refresh/service/RefreshTokenServiceIntegrationTest.java
+++ b/src/test/java/com/example/pillyohae/refresh/service/RefreshTokenServiceIntegrationTest.java
@@ -1,25 +1,62 @@
 package com.example.pillyohae.refresh.service;
 
-import com.example.pillyohae.global.util.JwtProvider;
-import com.example.pillyohae.user.entity.User;
-import com.example.pillyohae.user.repository.UserRepository;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
-@Transactional
 class RefreshTokenServiceIntegrationTest {
 
     @Autowired
     private RefreshTokenService refreshTokenService;
 
-    @Autowired
-    private JwtProvider jwtProvider;
+    @Test
+    @DisplayName("블랙리스트 조회 성능 테스트 - 동일한 토큰 반복 조회")
+    void blacklistLookupPerformanceTest() {
+        // 테스트용 토큰 생성
+        String testToken = "test_access_token";
 
-    @Autowired
-    private UserRepository userRepository;
+        // 블랙리스트에 추가
+        refreshTokenService.addToBlacklist("Bearer " + testToken);
 
-    private User testUser;
+        // 워밍업
+        for (int i = 0; i < 1000; i++) {
+            refreshTokenService.isTokenBlacklisted(testToken);
+        }
+
+        // 실제 성능 측정
+        long startTime = System.nanoTime();
+        for (int i = 0; i < 100000; i++) {
+            refreshTokenService.isTokenBlacklisted(testToken);
+        }
+        long endTime = System.nanoTime();
+
+        long durationInMillis = (endTime - startTime) / 1_000_000;
+        System.out.println("평균 조회 시간: " + (durationInMillis / 10000.0) + "ms");
+    }
+
+    @Test
+    @DisplayName("블랙리스트 조회 성능 테스트 - 서로 다른 토큰 조회")
+    void blacklistLookupPerformanceTestDifferentTokens() {
+        // 여러 개의 테스트 토큰 생성 및 블랙리스트 추가
+        List<String> tokens = IntStream.range(0, 10000)
+            .mapToObj(i -> "test_token_" + i)
+            .toList();
+
+        tokens.forEach(token ->
+            refreshTokenService.addToBlacklist("Bearer " + token));
+
+        // 성능 측정
+        long startTime = System.nanoTime();
+        tokens.forEach(token ->
+            refreshTokenService.isTokenBlacklisted(token));
+        long endTime = System.nanoTime();
+
+        long durationInMillis = (endTime - startTime) / 1_000_000;
+        System.out.println("평균 조회 시간: " + (durationInMillis / 1000.0) + "ms");
+    }
 
 }


### PR DESCRIPTION
caffeine 을 사용하여 블랙리스트를 캐싱에 저장하고
jwtAuthFilter 에서 블랙리스트에 있는지 검증하는 과정에
우선 캐시를 먼저 조회하도록 구현

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 토큰 블랙리스트 조회 성능 최적화를 위한 로컬 캐시 메커니즘 추가
	- Caffeine 캐싱 라이브러리 도입

- **성능 개선**
	- 토큰 블랙리스트 확인 시 Redis 호출 횟수 감소
	- 캐시를 통한 토큰 상태 확인 속도 향상

- **테스트**
	- 블랙리스트 조회 성능 테스트 추가
	- 다양한 토큰 시나리오에 대한 성능 측정 테스트 구현

<!-- end of auto-generated comment: release notes by coderabbit.ai -->