### PR TITLE
refactor: 이미지 삭제시 위치 재조정

### DIFF
--- a/src/main/java/com/example/pillyohae/product/entity/Product.java
+++ b/src/main/java/com/example/pillyohae/product/entity/Product.java
@@ -113,6 +113,7 @@ public class Product extends BaseTimeEntity {
             throw new CustomResponseStatusException(ErrorCode.LACK_OF_STOCK);
         }
         this.stock -= quantity; // 재고 차감
+        
         return this.stock; // 차감 후 남은 재고 반환
     }
 

--- a/src/main/java/com/example/pillyohae/product/entity/ProductImage.java
+++ b/src/main/java/com/example/pillyohae/product/entity/ProductImage.java
@@ -57,7 +57,7 @@ public class ProductImage {
         this.product = product;
     }
 
-    public ProductImage(String fileUrl, String fileKey, int position, Product findProduct) {
+    public ProductImage(String fileUrl, String fileKey, String contentType, int position, Product findProduct) {
         this.fileUrl = fileUrl;
         this.fileKey = fileKey;
         this.position = 0;

--- a/src/main/java/com/example/pillyohae/product/repository/ImageStorageRepository.java
+++ b/src/main/java/com/example/pillyohae/product/repository/ImageStorageRepository.java
@@ -21,11 +21,18 @@ public interface ImageStorageRepository extends JpaRepository<ProductImage, Long
 
     @Transactional
     @Modifying
-    @Query("UPDATE ProductImage pi SET pi.position = pi.position - 1 WHERE pi.product.productId = :productId AND pi.position > :deletedPosition")
+    @Query("DELETE FROM ProductImage pi " + "WHERE pi.product.productId = :productId " +
+        "AND pi.position = :deletedPosition " + "AND pi.id = :imageId")
+    void deleteImageByIdAndPosition(@Param("productId") Long productId, @Param("deletedPosition") Integer deletedPosition, @Param("imageId") Long imageId);
+
+    @Transactional
+    @Modifying
+    @Query("UPDATE ProductImage pi SET pi.position = pi.position - 1 " +
+        "WHERE pi.product.productId = :productId AND pi.position > :deletedPosition " + "AND :deletedPosition > 1 ")
     void updatePositionsAfterDelete(@Param("productId") Long productId, @Param("deletedPosition") Integer deletedPosition);
 
-    @Modifying
     @Transactional
+    @Modifying
     @Query("UPDATE ProductImage p SET p.position = p.position + 1 WHERE p.product.productId = :productId")
     void incrementAllPositions(@Param("productId") Long productId);
 


### PR DESCRIPTION
- 이미지 0,1번 이미지 삭제시 2번 이상의 위치의 이미지가 0,1번 위치는 침범하지 못하도록 수정하였습니다. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 제품 재고 차감 시 남은 재고 수량을 반환하는 기능 추가
	- 제품 이미지에 콘텐츠 유형(contentType) 정보 추가
	- 이미지 삭제 및 위치 업데이트 로직 개선

- **버그 수정**
	- AI 생성 이미지 관리 로직 최적화
	- 이미지 위치 업데이트 조건 세분화

- **리팩토링**
	- 이미지 저장소 및 서비스 로직 구조 개선
	- 엔티티 매니저 의존성 제거

<!-- end of auto-generated comment: release notes by coderabbit.ai -->