### PR TITLE
feature: 대표이미지 재생성시 1번 위치

### DIFF
--- a/src/main/java/com/example/pillyohae/global/exception/code/ErrorCode.java
+++ b/src/main/java/com/example/pillyohae/global/exception/code/ErrorCode.java
@@ -41,6 +41,7 @@ public enum ErrorCode {
     INVALID_IMAGE_PRODUCT_MATCH(HttpStatus.BAD_REQUEST, "상품에 해당하는 이미지가 아닙니다."),
     CANNOT_OVERLOAD_FILE(HttpStatus.BAD_REQUEST, "이미지는 최대 5개까지 업로드할 수 있습니다"),
     BAD_POSITION(HttpStatus.BAD_REQUEST, "위치 값은 0보다 작을 수 없습니다."),
+    IMAGE_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "기존의 대표이미지를 삭제해주세요"),
 
     /**
      * BadRequest

--- a/src/main/java/com/example/pillyohae/product/controller/ProductController.java
+++ b/src/main/java/com/example/pillyohae/product/controller/ProductController.java
@@ -148,6 +148,15 @@ public class ProductController {
         return new ResponseEntity<>(uploadFileInfo, HttpStatus.OK);
     }
 
+    @PostMapping("/products/{productId}/images/upload-main-image")
+    public ResponseEntity<UploadFileInfo> uploadMainImage(
+        @PathVariable Long productId,
+        @RequestParam(name = "image") MultipartFile MainImage
+    ) {
+        UploadFileInfo uploadImageToPositionOne = productService.uploadImageToPositionOne(productId, MainImage);
+        return new ResponseEntity<>(uploadImageToPositionOne, HttpStatus.OK);
+    }
+
     /**
      * 이미지 삭제
      *

--- a/src/main/java/com/example/pillyohae/product/dto/ProductGetResponseDto.java
+++ b/src/main/java/com/example/pillyohae/product/dto/ProductGetResponseDto.java
@@ -1,10 +1,11 @@
 package com.example.pillyohae.product.dto;
 
 import com.example.pillyohae.product.entity.type.ProductStatus;
-import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Getter
 public class ProductGetResponseDto {
@@ -19,8 +20,8 @@ public class ProductGetResponseDto {
     private List<ImageResponseDto> images;
 
     public ProductGetResponseDto(Long productId, String productName, String category,
-        String description, String companyName, Long price, ProductStatus status,
-        List<ImageResponseDto> images) {
+                                 String description, String companyName, Long price, ProductStatus status,
+                                 List<ImageResponseDto> images) {
         this.productId = productId;
         this.productName = productName;
         this.category = category;
@@ -36,6 +37,7 @@ public class ProductGetResponseDto {
     @AllArgsConstructor
     public static class ImageResponseDto {
 
+        private Long imageId;
         private String imageUrl;
         private Integer position;
     }


### PR DESCRIPTION
- 대표 이미지 재생성시 1번 위치로 들어가는 API
- 상품 조회_ImageResponseDto imageId 추가
- feature인데 refactor로 오기했습니다. 참고부탁드립니다..!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 제품의 대표 이미지 업로드 기능 추가
	- 이미지 업로드 시 중복 이미지에 대한 오류 처리 개선

- **버그 수정**
	- 이미지 관리 프로세스의 예외 처리 강화

- **개선 사항**
	- 제품 이미지 관리를 위한 새로운 API 엔드포인트 도입
	- 이미지 업로드 시 상세 정보 추적을 위한 이미지 ID 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->